### PR TITLE
feat : [KAN-309] 배포 오류 수정(완)

### DIFF
--- a/.github/workflows/deploy-api-to-prod.yml
+++ b/.github/workflows/deploy-api-to-prod.yml
@@ -47,7 +47,6 @@ jobs:
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
           docker buildx build --platform linux/amd64,linux/arm64 -f docker/api.Dockerfile -t camelia9999/dinningbuddy:be --push .
-          docker push camelia9999/dinningbuddy:be
       - name: Debug SSH key
         run: |
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > debug_key

--- a/.github/workflows/deploy-api-to-prod.yml
+++ b/.github/workflows/deploy-api-to-prod.yml
@@ -87,7 +87,7 @@ jobs:
             echo "> $IDLE_PROFILE 배포"
             docker-compose up -d skku-api-$IDLE_PROFILE
             
-            echo "> 사용하지 않는 Docker Image 삭제 
+            echo "> 사용하지 않는 Docker Image 삭제" 
             docker image prune -f
             
             sleep 60

--- a/.github/workflows/deploy-api-to-prod.yml
+++ b/.github/workflows/deploy-api-to-prod.yml
@@ -12,6 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Set Up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -40,7 +46,7 @@ jobs:
       - name: Docker Build And Push
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-          docker build -f docker/api.Dockerfile -t camelia9999/dinningbuddy:be .
+          docker buildx build --platform linux/amd64,linux/arm64 -f docker/api.Dockerfile -t camelia9999/dinningbuddy:be --push .
           docker push camelia9999/dinningbuddy:be
       - name: Debug SSH key
         run: |
@@ -81,6 +87,9 @@ jobs:
             
             echo "> $IDLE_PROFILE 배포"
             docker-compose up -d skku-api-$IDLE_PROFILE
+            
+            echo "> 사용하지 않는 Docker Image 삭제 
+            docker image prune -f
             
             sleep 60
             


### PR DESCRIPTION
더 이상 사용되지 않는 image가 지워지지 않아 disk용량을 차지하는 형태 확인.

기존의 containerName과 충돌되어 배포되지 않는 경우 확인