### PR TITLE
[KAN-350] fix : camelCase에도 운영시간이 반환됨을 확인

### DIFF
--- a/src/main/kotlin/com/restaurant/be/restaurant/domain/entity/kakaoinfo/OperationTimeInfoJsonEntity.kt
+++ b/src/main/kotlin/com/restaurant/be/restaurant/domain/entity/kakaoinfo/OperationTimeInfoJsonEntity.kt
@@ -2,6 +2,8 @@ package com.restaurant.be.restaurant.domain.entity.kakaoinfo
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.restaurant.be.restaurant.repository.dto.OperationTimeInfoEsDocument
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class OperationTimeInfoJsonEntity(
     @JsonProperty("startTime")
@@ -15,22 +17,14 @@ data class OperationTimeInfoJsonEntity(
     @JsonProperty("lastOrder")
     val lastOrder: String?
 
-) {
-    companion object {
-        fun create(
-            startTime: String,
-            endTime: String,
-            breakStartTime: String,
-            breakEndTime: String,
-            lastOrder: String
-        ): OperationTimeInfoJsonEntity {
-            return OperationTimeInfoJsonEntity(
-                startTime = startTime,
-                endTime = endTime,
-                breakStartTime = breakStartTime,
-                breakEndTime = breakEndTime,
-                lastOrder = lastOrder
-            )
-        }
-    }
+)
+
+fun OperationTimeInfoEsDocument.toResponse(): OperationTimeInfoJsonEntity {
+    return OperationTimeInfoJsonEntity(
+        startTime = this.startTime,
+        endTime = this.endTime,
+        breakStartTime = this.breakStartTime,
+        breakEndTime = this.breakEndTime,
+        lastOrder = this.lastOrder
+    )
 }

--- a/src/main/kotlin/com/restaurant/be/restaurant/domain/entity/kakaoinfo/OperationTimeInfosJsonEntity.kt
+++ b/src/main/kotlin/com/restaurant/be/restaurant/domain/entity/kakaoinfo/OperationTimeInfosJsonEntity.kt
@@ -2,6 +2,7 @@ package com.restaurant.be.restaurant.domain.entity.kakaoinfo
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.restaurant.be.restaurant.repository.dto.OperationTimeInfosEsDocument
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class OperationTimeInfosJsonEntity(
@@ -10,16 +11,11 @@ data class OperationTimeInfosJsonEntity(
     @JsonProperty("operationTimeInfo")
     val operationTimeInfo: OperationTimeInfoJsonEntity?
 
-) {
-    companion object {
-        fun create(
-            dayOfTheWeek: String,
-            operationTimeInfo: OperationTimeInfoJsonEntity
-        ): OperationTimeInfosJsonEntity {
-            return OperationTimeInfosJsonEntity(
-                dayOfTheWeek = dayOfTheWeek,
-                operationTimeInfo = operationTimeInfo
-            )
-        }
-    }
+)
+
+fun OperationTimeInfosEsDocument.toResponse(): OperationTimeInfosJsonEntity {
+    return OperationTimeInfosJsonEntity(
+        dayOfTheWeek = this.dayOfTheWeek,
+        operationTimeInfo = this.operationTimeInfo.toResponse()
+    )
 }

--- a/src/main/kotlin/com/restaurant/be/restaurant/domain/service/GetRestaurantService.kt
+++ b/src/main/kotlin/com/restaurant/be/restaurant/domain/service/GetRestaurantService.kt
@@ -2,6 +2,7 @@ package com.restaurant.be.restaurant.domain.service
 
 import com.restaurant.be.common.exception.NotFoundRestaurantException
 import com.restaurant.be.common.redis.RedisRepository
+import com.restaurant.be.restaurant.domain.entity.kakaoinfo.toResponse
 import com.restaurant.be.restaurant.presentation.controller.dto.GetRestaurantResponse
 import com.restaurant.be.restaurant.presentation.controller.dto.GetRestaurantsRequest
 import com.restaurant.be.restaurant.presentation.controller.dto.GetRestaurantsResponse
@@ -54,11 +55,21 @@ class GetRestaurantService(
             )
 
         val restaurantMap = restaurantProjections.associateBy { it.restaurant.id }
-        val sortedRestaurantProjections = restaurants.mapNotNull { restaurantMap[it.id] }
+
+        val sortedRestaurantProjections = restaurants.mapNotNull { esRestaurant ->
+            val projection = restaurantMap[esRestaurant.id] ?: return@mapNotNull null
+            val dto = projection.toDto()
+
+            esRestaurant.operationTimeInfos?.let { esOperationTimes
+                ->
+                dto.operationTimes = esOperationTimes.map { it.toResponse() }
+            }
+            dto
+        }
 
         return GetRestaurantsResponse(
             PageImpl(
-                sortedRestaurantProjections.map { it.toDto() },
+                sortedRestaurantProjections,
                 pageable,
                 sortedRestaurantProjections.size.toLong()
             ),


### PR DESCRIPTION
es와 rdb에 자료가 있음에도 property가 camelCase인 경우 반환되지 않음이 확인되어 이를 변환하는 내용이 추가되었습니다.